### PR TITLE
fix(zsh): bind abbr widgets to explicit keymaps

### DIFF
--- a/zsh/.zsh/.zsh_abbr_user
+++ b/zsh/.zsh/.zsh_abbr_user
@@ -117,7 +117,7 @@ abbrevs[@gd]="nvim -c ':DiffviewOpen'"
 abbrevs[@gdm]="nvim -c ':DiffviewOpen origin/main...HEAD'"
 abbrevs[@clod]="claude"
 abbrevs[@c]="claude"
-abbrevs[@dot]="cd ~/.dotfiles"
+abbrevs[@dot]="cd ${HOME}/.dotfiles"
 
 ###############################################################################
 # Pacman / AUR (Arch Linux)

--- a/zsh/.zsh/abbr.zsh
+++ b/zsh/.zsh/abbr.zsh
@@ -259,10 +259,14 @@ zle -N magic-abbrev-expand
 zle -N magic-abbrev-expand-and-execute
 zle -N no-magic-abbrev-expand
 
-# Key bindings
-bindkey " " magic-abbrev-expand
-bindkey "^M" magic-abbrev-expand-and-execute
-bindkey "^x " no-magic-abbrev-expand
+# Key bindings - bind to both viins and emacs so it works regardless of
+# whether set -o vi runs before or after this file is sourced
+for _abbr_km in viins emacs; do
+    bindkey -M $_abbr_km " " magic-abbrev-expand
+    bindkey -M $_abbr_km "^M" magic-abbrev-expand-and-execute
+    bindkey -M $_abbr_km "^x " no-magic-abbrev-expand
+done
+unset _abbr_km
 bindkey -M isearch " " self-insert
 
 ###############################################################################


### PR DESCRIPTION
Abbreviation expansion via Space/Enter was broken because abbr.zsh bound to the generic main keymap, which set -o vi then replaced with viins defaults. Bind to both viins and emacs explicitly so it works regardless of keymap switching order.